### PR TITLE
docs: fix cameras link in integrate_hardware (Fixes #2112)

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -35,6 +35,16 @@
     title: π₀.₅ (Pi05)
   - local: libero
     title: Using Libero
+  - local: policy_act_README
+    title: ACT Policy
+  - local: policy_diffusion_README
+    title: Diffusion Policy
+  - local: policy_smolvla_README
+    title: SmolVLA Policy
+  - local: policy_tdmpc_README
+    title: TDMPC Policy
+  - local: policy_vqbet_README
+    title: VQ-BET Policy
   title: "Policies"
 - sections:
   - local: introduction_processors

--- a/docs/source/integrate_hardware.mdx
+++ b/docs/source/integrate_hardware.mdx
@@ -65,7 +65,7 @@ class MyCoolRobotConfig(RobotConfig):
 ```
 <!-- prettier-ignore-end -->
 
-[Cameras tutorial](./cameras.mdx) to understand how to detect and add your camera.
+[Cameras tutorial](./cameras) to understand how to detect and add your camera.
 
 Next, we'll create our actual robot class which inherits from `Robot`. This abstract class defines a contract you must follow for your robot to be usable with the rest of the LeRobot tools.
 


### PR DESCRIPTION
## Problem
The "Cameras tutorial" link in integrate_hardware.mdx was pointing to ./cameras.mdx which resulted in a 404 error on the docs site.

## Solution
Changed the link from ./cameras.mdx to ./cameras to match the slug format defined in _toctree.yml
Added missing policy README pages to _toctree.yml to prevent build errors

## Changes
docs/source/integrate_hardware.mdx: Fixed cameras link
docs/source/_toctree.yml: Added missing policy pages (ACT, Diffusion, SmolVLA, TDMPC, VQ-BET)

## Testing
Built static docs locally and verified the link works
Link now correctly navigates to the cameras tutorial page
